### PR TITLE
Added functionalities to Monitor Pages 

### DIFF
--- a/API-Gateway/API-Gateway.Client/Pages/ClientMonitor.razor
+++ b/API-Gateway/API-Gateway.Client/Pages/ClientMonitor.razor
@@ -1,87 +1,121 @@
-﻿@page "/clientMonitor"
+﻿@page "/clientMonitor/{office}"
 @using Microsoft.AspNetCore.SignalR.Client;
 
 
 
-<h3>Monitor de oficina</h3>
+<h3>Monitor de @office</h3>
+
+<RadzenRow JustifyContent="JustifyContent.Center" AlignItems="AlignItems.Center">
+
+    <RadzenColumn >
+
+            <RadzenRow JustifyContent="JustifyContent.Left" AlignItems="AlignItems.Center">
+        <RadzenColumn>
+            <RadzenText TextStyle="TextStyle.H4">Cedula</RadzenText>
+        </RadzenColumn>
+
+        <RadzenColumn>
+            <RadzenText TextStyle="TextStyle.H4">Puesto de Atención</RadzenText>
+        </RadzenColumn>
+        </RadzenRow>
+
+    </RadzenColumn>
+</RadzenRow>
+        <RadzenDataList Data="@data" TItem="Client" PagerHorizontalAlign="HorizontalAlign.Left" ShowPagingSummary="true">
+            <Template Context="client">
+
+                
+
+                <RadzenCard Variant="Variant.Filled" class="rz-p-0" Style="width: 100%; overflow: hidden;">
+                    <RadzenRow Gap="0">
+                        <RadzenColumn Size="12" SizeLG="6" class="rz-p-4">
+                            <RadzenText TextStyle="TextStyle.H3" >@(client.clientCi)</RadzenText>
+                        </RadzenColumn>
+
+                        <RadzenColumn Size="10" SizeLG="5" class="rz-p-4">
+                            <RadzenRow Gap="0">
+                                <RadzenColumn Size="10" SizeMD="4" SizeLG="2">
+                                    <RadzenText TextStyle="TextStyle.H3" TextAlign="TextAlign.Center">@(client.attentionPlace)</RadzenText>
+                                </RadzenColumn>
+
+                            </RadzenRow>
+                        </RadzenColumn>
+                    </RadzenRow>
+                </RadzenCard>
+            </Template>
+        </RadzenDataList>
 
 
-<table class="table">
-    <thead>
-        <tr>
-            <th>
-                N° de puesto
-            </th>
-            <th>
-                Cedula
-            </th>
-            <th>
-                N° Oficina
-            </th>
-        </tr>
-    </thead>
-    <tbody>
 
-    @foreach (var i in models){
-        <tr>
-            <td>
-                @i.Value.attentionPlace
-            </td>
-            <td>
-                @i.Value.clientCi
-            </td>
-            <td>
-                @i.Value.officeId
-            </td>
 
-        </tr>
-    }
-            
-        
-    </tbody>
-</table>
+
+<style>
+.product-title {
+    min-height: 72px;
+    background-color: var(--rz-secondary-lighter);
+}
+.price-badge {
+    font-size: 16px;
+    font-weight: bold;
+    line-height: 20px;
+    padding: 8px;
+}
+</style>
 
 
 @code {
 
+    //creamos el hub con el que nos conectaremos
     HubConnection _connection;
 
-    class Model
-    {
+    //creamos el modelo de datos que vamos a usar
+    public class Client{
         public string clientCi { get; set; }
         public long attentionPlace { get; set; }
         public string officeId { get; set; }
     }
 
-    IDictionary<long,Model> models = new Dictionary<long,Model>();
+    //el ID de al oficina que nos llega por la URI
+    [Parameter]
+    public string office { get; set; }
+
+    static IDictionary<long,Client> clients = new Dictionary<long,Client>();
+
+    //ICollection<<IDictionary<long, Client>> clientEnumerable = new List<IDictionary<long, Client>> { clients };
+    //IEnumerable<IDictionary<long, Client>> clientEnumerable = new Dictionary<long,object>();
+
+    ICollection<Client> data = clients.Values;
+    //IQueryable<Client> clientQueryable;
+    //ICollection<Client> data = clientEnumerable.First().Values;
 
     protected override async Task OnInitializedAsync(){
         
         Console.WriteLine("Se inicializó el componente del monitor en API Gateway");
 
+        //TODO: update this hub with the thingy service discovery from Aspire
         _connection = new HubConnectionBuilder().WithUrl("http://localhost:5030/commercial-office/hub").Build();
 
-        _connection.On("RefreshMonitor", (string userId, long post, string officeId) =>
+        _connection.On("RefreshMonitor"+office, (string userId, long post, string officeId) =>
         {
             Console.WriteLine($"Datos recibidos mediante SignalR: {userId}, {post}, {officeId}");
 
-            Model model = new Model();
+            Client model = new Client();
 
             model.clientCi = userId;
             model.attentionPlace = post;
             model.officeId = officeId;
 
-            if (models.ContainsKey(post)){//si se encuentra el puesto ya ocupado
+            if (clients.ContainsKey(post)){//si se encuentra el puesto ya ocupado
 
-                models.Remove(model.attentionPlace);//lo liberamos
+                clients.Remove(model.attentionPlace);//lo liberamos
             }
 
             if (!model.clientCi.Equals("remove"))//si el llamado no es solo para remover, también añadimos al usuario al puesto
             {
-                models.Add(model.attentionPlace, model);
+                clients.Add(model.attentionPlace, model);
             }
 
-
+            data = clients.Values;
             //Le avisamos al componente que se re-renderize dado que su estádo ha cambiado
             InvokeAsync(StateHasChanged);
         });

--- a/API-Gateway/API-Gateway.Client/Pages/Home.razor
+++ b/API-Gateway/API-Gateway.Client/Pages/Home.razor
@@ -2,41 +2,68 @@
 @using Microsoft.AspNetCore.SignalR.Client;
 @using API_Gateway_Client.DTOs
 @using Newtonsoft.Json;
+@inject NavigationManager NavigationManager
 
 <PageTitle>Home</PageTitle>
 
 
-<h1>Para testear dirigase a la pestaña del monitor</h1>
-<RadzenButton Click="@ButtonClicked" Text="Hi"></RadzenButton>
+<h1>Oficinas disponibles:</h1>
+
+@foreach (var i in offices)
+{
+    <tr>
+        <td>
+            <h3>
+                <a href="@NavigationManager.ToAbsoluteUri("/clientMonitor/" + i.Identificator)">@i.Identificator</a>
+            </h3>
+        </td>
+    </tr>
+}
+
+
+
+
+<RadzenButton Click="@ButtonClicked" Text="Actualizar Lista de Monitores"></RadzenButton>
+
 @code{
 
     static readonly HttpClient client = new HttpClient();
 
+    IList<OfficeDTO> offices = new List<OfficeDTO>();
+
+    //Cuando se inicializa el componente:
     protected override async Task OnInitializedAsync()
     {
-        IList<OfficeDTO> offices = new List<OfficeDTO>();
+        ReloadOfficeList();
 
+    }
+
+    void ButtonClicked()
+    {
+        //TODO: chekc if I can find a way of routing this page dinamically :7
+        //Console.WriteLine(NavigationManager.GetUriWithQueryParameter("clientMonitor", offices[0].Identificator));
+
+        ReloadOfficeList();
+        //Console.WriteLine(NavigationManager.ToAbsoluteUri("/monitorClient/" + offices[0].Identificator));
+
+    }
+
+    async void ReloadOfficeList()
+    {
+        //conseguimos todas las oficinas desde CommercialOffice
         try
         {
             string response = await client.GetStringAsync("http://localhost:5030/office/getAllOffices");
 
             offices = JsonConvert.DeserializeObject<List<OfficeDTO>>(response);
 
-            Console.WriteLine(offices.Count);
-
-
-            for(int i = 0; offices.Count > i; i++) {
-                Console.WriteLine(offices[i].Identificator);
-            }
-
-        }catch(Exception e)
+            //Le avisamos al componente que se re-renderize dado que su estádo ha cambiado
+            InvokeAsync(StateHasChanged);
+        }
+        catch (Exception e)
         {
             Console.WriteLine(e.Message);
         }
     }
 
-    void ButtonClicked()
-    {
-        Console.WriteLine("La wawa! botón Ryzen pum pere! :D");
-    }
 }

--- a/Commercial-Office/Services/OfficeService.cs
+++ b/Commercial-Office/Services/OfficeService.cs
@@ -297,7 +297,7 @@ namespace Commercial_Office.Services
 
                     //TODO: Consultar
                     //desde Apigateway
-                    _hub.Clients.All.SendAsync("RefreshMonitor", userId.Item, place.Number, officeId);
+                    _hub.Clients.All.SendAsync("RefreshMonitor"+officeId, userId.Item, place.Number, officeId);
 
                 }
                 else
@@ -352,7 +352,7 @@ namespace Commercial_Office.Services
                     //TODO: Consultar
                     //desde Apigateway
 
-                    _hub.Clients.All.SendAsync("RefreshMonitor", "remove", place.Number, officeId); 
+                    _hub.Clients.All.SendAsync("RefreshMonitor"+ officeId, "remove", place.Number, officeId); 
 
                     await task;
                 }


### PR DESCRIPTION
# Overview
Home.razor now shows a list of all currently available offices, alongside with a button to refresh them.
clicking on any of them leads you to the specific clientMonitor of the given Office rather than all of them.

# IMPORTANT
Now the OfficeService's calls to hub connections have the ID of the office concatenated at the end of the call.
I.E /RefreshMonitorOFI-2


https://github.com/user-attachments/assets/a904399e-27a7-4da2-8e36-7e91edeb5b44

